### PR TITLE
Removed kconv

### DIFF
--- a/libraries.json
+++ b/libraries.json
@@ -29,15 +29,6 @@
       "maintainer": "Koichi Sasada (ko1)"
     },
     {
-      "gem": "kconv",
-      "native": false,
-      "autoRequire": false,
-      "description": "Adds the `Kconv.kconv` function which wraps the nkf (standard) library",
-      "mriSourcePath": "ext/nkf/lib/kconv.rb",
-      "rdocLink": "https://ruby-doc.org/stdlib-2.5.0/libdoc/nkf/rdoc/Kconv.html",
-      "maintainer": "NARUSE, Yui (narse)"
-    },
-    {
       "gem": "mkmf",
       "native": false,
       "autoRequire": false,


### PR DESCRIPTION
kconv is a part of nkf, not an independent library.