### PR TITLE
Fix default optparse version on ruby 3.0

### DIFF
--- a/default_gems.json
+++ b/default_gems.json
@@ -832,7 +832,7 @@
       "rdocLink": "https://ruby-doc.org/stdlib/libdoc/optparse/rdoc/OptParse.html",
       "maintainer": "Nobuyuki Nakada (nobu)",
       "versions": {
-        "3.0": "1.0.0"
+        "3.0": "0.1.0"
       }
     },
     {


### PR DESCRIPTION
Version 1.0.0 doesn't yet exist.