### PR TITLE
Change the alternative for matrix from nmatrix to numo-narray

### DIFF
--- a/bundled_gems.json
+++ b/bundled_gems.json
@@ -44,7 +44,7 @@
       "rubygemsLink": "https://rubygems.org/gems/matrix",
       "rdocLink": "https://www.rubydoc.info/gems/matrix",
       "alternatives": {
-        "nmatrix": "https://github.com/SciRuby/nmatrix"
+        "numo-narray": "https://github.com/ruby-numo/numo-narray"
       },
       "versions": {
         "3.2": "0.4.2",


### PR DESCRIPTION
Hello.

I came to this site from the badge in the README of [matrix](https://github.com/ruby/matrix).

I noticed that [nmatrix](https://github.com/SciRuby/nmatrix) is proposed as an alternative to matrix. 
Unfortunately, nmatrix has not been maintained for several years. Today's Ruby machine learning library experts, such as [Andrew Kane](https://github.com/ankane) and [Atsushi Tatsuma](https://github.com/yoshoku), build their tools using numo-narray rather than nmatrix.

* [rumale](https://github.com/yoshoku/rumale)
* [torch.rb](https://github.com/ankane/torch.rb)
* https://ankane.org/numo

In my benchmarks numo-narray is faster than nmatrix. 

Please consider changing.