### PR TITLE
Fix typo in Markdown for rubygems

### DIFF
--- a/default_gems.json
+++ b/default_gems.json
@@ -1700,7 +1700,7 @@
         "Eric Hodel (drbrain)",
         "Hiroshi SHIBATA (hsbt)"
       ],
-      "notes": "- You can [prevent Ruby from loading RubyGems (and any gems)]((https://idiosyncratic-ruby.com/71-nothing-to-disable.html)) with `$ ruby --disable-gems`",
+      "notes": "- You can [prevent Ruby from loading RubyGems (and any gems)](https://idiosyncratic-ruby.com/71-nothing-to-disable.html) with `$ ruby --disable-gems`",
       "versions": {
         "3.2":     "3.4.0",
 


### PR DESCRIPTION
Fixes up 3fcdee3b5ecaa78ee09568eafd37ae91610bdb19

Signed-off-by: Takuya Noguchi [takninnovationresearch@gmail.com](https://github.com/sponsors/tnir)