### PR TITLE
abbrev is 0.1.1 in ruby 3.2.0

### DIFF
--- a/default_gems.json
+++ b/default_gems.json
@@ -13,7 +13,7 @@
       "rdocLink": "https://ruby-doc.org/stdlib/libdoc/abbrev/rdoc/Abbrev.html",
       "maintainer": "Akinori MUSHA (knu)",
       "versions": {
-        "3.2": "0.1.0",
+        "3.2": "0.1.1",
         "3.1": "0.1.0",
         "3.0": "0.1.0"
       }


### PR DESCRIPTION
abbrev gem is [0.1.1](https://github.com/ruby/ruby/commit/0b67e435ed07a2febf7c7bd4911257a8f4836779) in ruby 3.2.0 final release.

This found by [auto commit](https://github.com/ruby/ruby/commit/d29096f4a894c112b64ea860bdc2c71ad2e8eaaf) of [check_misc](https://github.com/ruby/ruby/blob/db19714b17e365d11ceb13e0d16c8cf3c837f38c/.github/workflows/check_misc.yml).