### PR TITLE
Mark erb as using native extensions

### DIFF
--- a/default_gems.json
+++ b/default_gems.json
@@ -492,7 +492,7 @@
     },
     {
       "gem": "erb",
-      "native": false,
+      "native": true,
       "autoRequire": false,
       "description": "Templating engine for Ruby",
       "mriSourcePath": "lib/erb.rb",


### PR DESCRIPTION
As part of Ruby feature #19102[1], erb implemented native extensions in ruby/erb@ac9b219fa99b14272d3157c4ffd1330f471c1d51, which was included in erb 4.0.0 and on.

This commit updates the default_gems hash to specify that erb uses native extensions.

[1] https://bugs.ruby-lang.org/issues/19102